### PR TITLE
Translated using Weblate (Danish)

### DIFF
--- a/language/resource.language.da_dk/strings.po
+++ b/language/resource.language.da_dk/strings.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: KODI Skins\n"
 "Report-Msgid-Bugs-To: http://trac.kodi.tv/\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2020-10-21 21:50+0000\n"
+"PO-Revision-Date: 2020-10-24 19:38+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
 "Language-Team: Danish <https://kodi.weblate.cloud/projects/test-component/"
 "skin-rapier-test/da_dk/>\n"
@@ -31,7 +31,7 @@ msgstr ""
 #: /720p/script-script.extendedinfo-DialogVideoInfo.xml
 msgctxt "#31000"
 msgid "Unavailable"
-msgstr "Ikke tilgængelig"
+msgstr "Ikke tilgængeligfff"
 
 #: /720p/DialogMusicInfo.xml /720p/DialogPlayerProcessInfo.xml
 #: /720p/includes_Addons.xml /720p/includes_PVR.xml /720p/includes_Weather.xml
@@ -39,12 +39,12 @@ msgstr "Ikke tilgængelig"
 #: /720p/script-script.extendedinfo-DialogVideoInfo.xml /720p/Views.xml
 msgctxt "#31001"
 msgid "N/A"
-msgstr "Ikke tilgængelig more tests more tests"
+msgstr "Ikke tilgængelig more tests more testssds"
 
 #: /720p/VideoOSD.xml
 msgctxt "#31002"
 msgid "Teletext"
-msgstr "Tekst-tvhhh"
+msgstr "Tekst-tv"
 
 #. Short for minutes
 #: /720p/includes_InfoPane.xml /720p/script-globalsearch-infodialog.xml
@@ -1487,7 +1487,7 @@ msgstr "Normal"
 #: /720p/DialogButtonMenu.xml
 msgctxt "#31420"
 msgid "Reboot from internal"
-msgstr ""
+msgstr "Intern genstart"
 
 #: /720p/includes_SkinSettingsMenus.xml /720p/SkinSettings.xml
 msgctxt "#31421"
@@ -2186,7 +2186,7 @@ msgstr "Genstart Kodi"
 #: /720p/includes_InfoPane.xml
 msgctxt "#31708"
 msgid "Git"
-msgstr ""
+msgstr "Git"
 
 #: /720p/includes_SkinSettingsHome.xml
 msgctxt "#31709"


### PR DESCRIPTION
Currently translated at 96.8% (456 of 471 strings)

Translated using Weblate (Danish)

Currently translated at 96.8% (456 of 471 strings)

Co-authored-by: Christian Gade <gade@kodi.tv>
Co-authored-by: Hosted Weblate <hosted@weblate.org>
Translate-URL: https://kodi.weblate.cloud/projects/test-component/skin-rapier-test/da_dk/
Translation: test-component/skin.rapier.test