### PR TITLE
Fix artwork in custom top/bottom widgets

### DIFF
--- a/720p/includes_HomeCustomWidgets.xml
+++ b/720p/includes_HomeCustomWidgets.xml
@@ -58,76 +58,6 @@
 		</control>
 	</include>
 	
-	<variable name="CustomPanelThumbTop">
-		<value condition="Container(850).HasFocus(7) + [Skin.String(Custom1PanelType,2) | Skin.String(Custom1PanelType,4) | Skin.String(Custom1PanelType,10) | Skin.String(Custom1PanelType,11) | Skin.String(Custom1PanelType,12)]">$INFO[Container(6894).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(7) + [Skin.String(Custom1PanelType,3) | Skin.String(Custom1PanelType,5) | Skin.String(Custom1PanelType,6) | Skin.String(Custom1PanelType,7) | Skin.String(Custom1PanelType,8) | Skin.String(Custom1PanelType,9) | Skin.String(Custom1PanelType,13) | Skin.String(Custom1PanelType,14) | Skin.String(Custom1PanelType,15)]">$INFO[Container(6894).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(8) + [Skin.String(Custom2PanelType,2) | Skin.String(Custom2PanelType,4) | Skin.String(Custom2PanelType,10) | Skin.String(Custom2PanelType,11) | Skin.String(Custom2PanelType,12)]">$INFO[Container(6896).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(8) + [Skin.String(Custom2PanelType,3) | Skin.String(Custom2PanelType,5) | Skin.String(Custom2PanelType,6) | Skin.String(Custom2PanelType,7) | Skin.String(Custom2PanelType,8) | Skin.String(Custom2PanelType,9) | Skin.String(Custom2PanelType,13) | Skin.String(Custom2PanelType,14) | Skin.String(Custom2PanelType,15)]">$INFO[Container(6896).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(9) + [Skin.String(Custom3PanelType,2) | Skin.String(Custom3PanelType,4) | Skin.String(Custom3PanelType,10) | Skin.String(Custom3PanelType,11) | Skin.String(Custom3PanelType,12)]">$INFO[Container(6898).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(9) + [Skin.String(Custom3PanelType,3) | Skin.String(Custom3PanelType,5) | Skin.String(Custom3PanelType,6) | Skin.String(Custom3PanelType,7) | Skin.String(Custom3PanelType,8) | Skin.String(Custom3PanelType,9) | Skin.String(Custom3PanelType,13) | Skin.String(Custom3PanelType,14) | Skin.String(Custom3PanelType,15)]">$INFO[Container(6898).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(10) + [Skin.String(Custom4PanelType,2) | Skin.String(Custom4PanelType,4) | Skin.String(Custom4PanelType,10) | Skin.String(Custom4PanelType,11) | Skin.String(Custom4PanelType,12)]">$INFO[Container(6900).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(10) + [Skin.String(Custom4PanelType,3) | Skin.String(Custom4PanelType,5) | Skin.String(Custom4PanelType,6) | Skin.String(Custom4PanelType,7) | Skin.String(Custom4PanelType,8) | Skin.String(Custom4PanelType,9) | Skin.String(Custom4PanelType,13) | Skin.String(Custom4PanelType,14) | Skin.String(Custom4PanelType,15)]">$INFO[Container(6900).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(11) + [Skin.String(Custom5PanelType,2) | Skin.String(Custom5PanelType,4) | Skin.String(Custom5PanelType,10) | Skin.String(Custom5PanelType,11) | Skin.String(Custom5PanelType,12)]">$INFO[Container(6902).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(11) + [Skin.String(Custom5PanelType,3) | Skin.String(Custom5PanelType,5) | Skin.String(Custom5PanelType,6) | Skin.String(Custom5PanelType,7) | Skin.String(Custom5PanelType,8) | Skin.String(Custom5PanelType,9) | Skin.String(Custom5PanelType,13) | Skin.String(Custom5PanelType,14) | Skin.String(Custom5PanelType,15)]">$INFO[Container(6902).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(12) + [Skin.String(Custom6PanelType,2) | Skin.String(Custom6PanelType,4) | Skin.String(Custom6PanelType,10) | Skin.String(Custom6PanelType,11) | Skin.String(Custom6PanelType,12)]">$INFO[Container(6904).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(12) + [Skin.String(Custom6PanelType,3) | Skin.String(Custom6PanelType,5) | Skin.String(Custom6PanelType,6) | Skin.String(Custom6PanelType,7) | Skin.String(Custom6PanelType,8) | Skin.String(Custom6PanelType,9) | Skin.String(Custom6PanelType,13) | Skin.String(Custom6PanelType,14) | Skin.String(Custom6PanelType,15)]">$INFO[Container(6904).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(13) + [Skin.String(Custom7PanelType,2) | Skin.String(Custom7PanelType,4) | Skin.String(Custom7PanelType,10) | Skin.String(Custom7PanelType,11) | Skin.String(Custom7PanelType,12)]">$INFO[Container(6906).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(13) + [Skin.String(Custom7PanelType,3) | Skin.String(Custom7PanelType,5) | Skin.String(Custom7PanelType,6) | Skin.String(Custom7PanelType,7) | Skin.String(Custom7PanelType,8) | Skin.String(Custom7PanelType,9) | Skin.String(Custom7PanelType,13) | Skin.String(Custom7PanelType,14) | Skin.String(Custom7PanelType,15)]">$INFO[Container(6906).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(14) + [Skin.String(Custom8PanelType,2) | Skin.String(Custom8PanelType,4) | Skin.String(Custom8PanelType,10) | Skin.String(Custom8PanelType,11) | Skin.String(Custom8PanelType,12)]">$INFO[Container(6908).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(14) + [Skin.String(Custom8PanelType,3) | Skin.String(Custom8PanelType,5) | Skin.String(Custom8PanelType,6) | Skin.String(Custom8PanelType,7) | Skin.String(Custom8PanelType,8) | Skin.String(Custom8PanelType,9) | Skin.String(Custom8PanelType,13) | Skin.String(Custom8PanelType,14) | Skin.String(Custom8PanelType,15)]">$INFO[Container(6908).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(17) + [Skin.String(Custom9PanelType,2) | Skin.String(Custom9PanelType,4) | Skin.String(Custom9PanelType,10) | Skin.String(Custom9PanelType,11) | Skin.String(Custom9PanelType,12)]">$INFO[Container(6910).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(17) + [Skin.String(Custom9PanelType,3) | Skin.String(Custom9PanelType,5) | Skin.String(Custom9PanelType,6) | Skin.String(Custom9PanelType,7) | Skin.String(Custom9PanelType,8) | Skin.String(Custom9PanelType,9) | Skin.String(Custom9PanelType,13) | Skin.String(Custom9PanelType,14) | Skin.String(Custom9PanelType,15)]">$INFO[Container(6910).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(18) + [Skin.String(Custom10PanelType,2) | Skin.String(Custom10PanelType,4) | Skin.String(Custom10PanelType,10) | Skin.String(Custom10PanelType,11) | Skin.String(Custom10PanelType,12)]">$INFO[Container(6912).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(18) + [Skin.String(Custom10PanelType,3) | Skin.String(Custom10PanelType,5) | Skin.String(Custom10PanelType,6) | Skin.String(Custom10PanelType,7) | Skin.String(Custom10PanelType,8) | Skin.String(Custom10PanelType,9) | Skin.String(Custom10PanelType,13) | Skin.String(Custom10PanelType,14) | Skin.String(Custom10PanelType,15)]">$INFO[Container(6912).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(19) + [Skin.String(Custom11PanelType,2) | Skin.String(Custom11PanelType,4) | Skin.String(Custom11PanelType,10) | Skin.String(Custom11PanelType,11) | Skin.String(Custom11PanelType,12)]">$INFO[Container(6914).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(19) + [Skin.String(Custom11PanelType,3) | Skin.String(Custom11PanelType,5) | Skin.String(Custom11PanelType,6) | Skin.String(Custom11PanelType,7) | Skin.String(Custom11PanelType,8) | Skin.String(Custom11PanelType,9) | Skin.String(Custom11PanelType,13) | Skin.String(Custom11PanelType,14) | Skin.String(Custom11PanelType,15)]">$INFO[Container(6914).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(20) + [Skin.String(Custom12PanelType,2) | Skin.String(Custom12PanelType,4) | Skin.String(Custom12PanelType,10) | Skin.String(Custom12PanelType,11) | Skin.String(Custom12PanelType,12)]">$INFO[Container(6916).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(20) + [Skin.String(Custom12PanelType,3) | Skin.String(Custom12PanelType,5) | Skin.String(Custom12PanelType,6) | Skin.String(Custom12PanelType,7) | Skin.String(Custom12PanelType,8) | Skin.String(Custom12PanelType,9) | Skin.String(Custom12PanelType,13) | Skin.String(Custom12PanelType,14) | Skin.String(Custom12PanelType,15)]">$INFO[Container(6916).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(21) + [Skin.String(Custom13PanelType,2) | Skin.String(Custom13PanelType,4) | Skin.String(Custom13PanelType,10) | Skin.String(Custom13PanelType,11) | Skin.String(Custom13PanelType,12)]">$INFO[Container(6918).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(21) + [Skin.String(Custom13PanelType,3) | Skin.String(Custom13PanelType,5) | Skin.String(Custom13PanelType,6) | Skin.String(Custom13PanelType,7) | Skin.String(Custom13PanelType,8) | Skin.String(Custom13PanelType,9) | Skin.String(Custom13PanelType,13) | Skin.String(Custom13PanelType,14) | Skin.String(Custom13PanelType,15)]">$INFO[Container(6918).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(22) + [Skin.String(Custom14PanelType,2) | Skin.String(Custom14PanelType,4) | Skin.String(Custom14PanelType,10) | Skin.String(Custom14PanelType,11) | Skin.String(Custom14PanelType,12)]">$INFO[Container(6920).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(22) + [Skin.String(Custom14PanelType,3) | Skin.String(Custom14PanelType,5) | Skin.String(Custom14PanelType,6) | Skin.String(Custom14PanelType,7) | Skin.String(Custom14PanelType,8) | Skin.String(Custom14PanelType,9) | Skin.String(Custom14PanelType,13) | Skin.String(Custom14PanelType,14) | Skin.String(Custom14PanelType,15)]">$INFO[Container(6920).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(23) + [Skin.String(Custom15PanelType,2) | Skin.String(Custom15PanelType,4) | Skin.String(Custom15PanelType,10) | Skin.String(Custom15PanelType,11) | Skin.String(Custom15PanelType,12)]">$INFO[Container(6922).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(23) + [Skin.String(Custom15PanelType,3) | Skin.String(Custom15PanelType,5) | Skin.String(Custom15PanelType,6) | Skin.String(Custom15PanelType,7) | Skin.String(Custom15PanelType,8) | Skin.String(Custom15PanelType,9) | Skin.String(Custom15PanelType,13) | Skin.String(Custom15PanelType,14) | Skin.String(Custom15PanelType,15)]">$INFO[Container(6922).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(24) + [Skin.String(Custom16PanelType,2) | Skin.String(Custom16PanelType,4) | Skin.String(Custom16PanelType,10) | Skin.String(Custom16PanelType,11) | Skin.String(Custom16PanelType,12)]">$INFO[Container(6924).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(24) + [Skin.String(Custom16PanelType,3) | Skin.String(Custom16PanelType,5) | Skin.String(Custom16PanelType,6) | Skin.String(Custom16PanelType,7) | Skin.String(Custom16PanelType,8) | Skin.String(Custom16PanelType,9) | Skin.String(Custom16PanelType,13) | Skin.String(Custom16PanelType,14) | Skin.String(Custom16PanelType,15)]">$INFO[Container(6924).ListItem.Art(thumb)]</value>
-	</variable>
-	
-	<variable name="CustomPanelThumbBottom">
-		<value condition="Container(850).HasFocus(7) + [Skin.String(Custom1PanelType,2) | Skin.String(Custom1PanelType,4) | Skin.String(Custom1PanelType,10) | Skin.String(Custom1PanelType,11) | Skin.String(Custom1PanelType,12)]">$INFO[Container(6895).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(7) + [Skin.String(Custom1PanelType,3) | Skin.String(Custom1PanelType,5) | Skin.String(Custom1PanelType,6) | Skin.String(Custom1PanelType,7) | Skin.String(Custom1PanelType,8) | Skin.String(Custom1PanelType,9) | Skin.String(Custom1PanelType,13) | Skin.String(Custom1PanelType,15)]">$INFO[Container(6895).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(8) + [Skin.String(Custom2PanelType,2) | Skin.String(Custom2PanelType,4) | Skin.String(Custom2PanelType,10) | Skin.String(Custom2PanelType,11) | Skin.String(Custom2PanelType,12)]">$INFO[Container(6897).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(8) + [Skin.String(Custom2PanelType,3) | Skin.String(Custom2PanelType,5) | Skin.String(Custom2PanelType,6) | Skin.String(Custom2PanelType,7) | Skin.String(Custom2PanelType,8) | Skin.String(Custom2PanelType,9) | Skin.String(Custom2PanelType,13) | Skin.String(Custom2PanelType,15)]">$INFO[Container(6897).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(9) + [Skin.String(Custom3PanelType,2) | Skin.String(Custom3PanelType,4) | Skin.String(Custom3PanelType,10) | Skin.String(Custom3PanelType,11) | Skin.String(Custom3PanelType,12)]">$INFO[Container(6899).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(9) + [Skin.String(Custom3PanelType,3) | Skin.String(Custom3PanelType,5) | Skin.String(Custom3PanelType,6) | Skin.String(Custom3PanelType,7) | Skin.String(Custom3PanelType,8) | Skin.String(Custom3PanelType,9) | Skin.String(Custom3PanelType,13) | Skin.String(Custom3PanelType,15)]">$INFO[Container(6899).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(10) + [Skin.String(Custom4PanelType,2) | Skin.String(Custom4PanelType,4) | Skin.String(Custom4PanelType,10) | Skin.String(Custom4PanelType,11) | Skin.String(Custom4PanelType,12)]">$INFO[Container(6901).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(10) + [Skin.String(Custom4PanelType,3) | Skin.String(Custom4PanelType,5) | Skin.String(Custom4PanelType,6) | Skin.String(Custom4PanelType,7) | Skin.String(Custom4PanelType,8) | Skin.String(Custom4PanelType,9) | Skin.String(Custom4PanelType,13) | Skin.String(Custom4PanelType,15)]">$INFO[Container(6901).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(11) + [Skin.String(Custom5PanelType,2) | Skin.String(Custom5PanelType,4) | Skin.String(Custom5PanelType,10) | Skin.String(Custom5PanelType,11) | Skin.String(Custom5PanelType,12)]">$INFO[Container(6903).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(11) + [Skin.String(Custom5PanelType,3) | Skin.String(Custom5PanelType,5) | Skin.String(Custom5PanelType,6) | Skin.String(Custom5PanelType,7) | Skin.String(Custom5PanelType,8) | Skin.String(Custom5PanelType,9) | Skin.String(Custom5PanelType,13) | Skin.String(Custom5PanelType,15)]">$INFO[Container(6903).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(12) + [Skin.String(Custom6PanelType,2) | Skin.String(Custom6PanelType,4) | Skin.String(Custom6PanelType,10) | Skin.String(Custom6PanelType,11) | Skin.String(Custom6PanelType,12)]">$INFO[Container(6905).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(12) + [Skin.String(Custom6PanelType,3) | Skin.String(Custom6PanelType,5) | Skin.String(Custom6PanelType,6) | Skin.String(Custom6PanelType,7) | Skin.String(Custom6PanelType,8) | Skin.String(Custom6PanelType,9) | Skin.String(Custom6PanelType,13) | Skin.String(Custom6PanelType,15)]">$INFO[Container(6905).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(13) + [Skin.String(Custom7PanelType,2) | Skin.String(Custom7PanelType,4) | Skin.String(Custom7PanelType,10) | Skin.String(Custom7PanelType,11) | Skin.String(Custom7PanelType,12)]">$INFO[Container(6907).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(13) + [Skin.String(Custom7PanelType,3) | Skin.String(Custom7PanelType,5) | Skin.String(Custom7PanelType,6) | Skin.String(Custom7PanelType,7) | Skin.String(Custom7PanelType,8) | Skin.String(Custom7PanelType,9) | Skin.String(Custom7PanelType,13) | Skin.String(Custom7PanelType,15)]">$INFO[Container(6907).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(14) + [Skin.String(Custom8PanelType,2) | Skin.String(Custom8PanelType,4) | Skin.String(Custom8PanelType,10) | Skin.String(Custom8PanelType,11) | Skin.String(Custom8PanelType,12)]">$INFO[Container(6909).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(14) + [Skin.String(Custom8PanelType,3) | Skin.String(Custom8PanelType,5) | Skin.String(Custom8PanelType,6) | Skin.String(Custom8PanelType,7) | Skin.String(Custom8PanelType,8) | Skin.String(Custom8PanelType,9) | Skin.String(Custom8PanelType,13) | Skin.String(Custom8PanelType,15)]">$INFO[Container(6909).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(17) + [Skin.String(Custom9PanelType,2) | Skin.String(Custom9PanelType,4) | Skin.String(Custom9PanelType,10) | Skin.String(Custom9PanelType,11) | Skin.String(Custom9PanelType,12)]">$INFO[Container(6911).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(17) + [Skin.String(Custom9PanelType,3) | Skin.String(Custom9PanelType,5) | Skin.String(Custom9PanelType,6) | Skin.String(Custom9PanelType,7) | Skin.String(Custom9PanelType,8) | Skin.String(Custom9PanelType,9) | Skin.String(Custom9PanelType,13) | Skin.String(Custom9PanelType,15)]">$INFO[Container(6911).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(18) + [Skin.String(Custom10PanelType,2) | Skin.String(Custom10PanelType,4) | Skin.String(Custom10PanelType,10) | Skin.String(Custom10PanelType,11) | Skin.String(Custom10PanelType,12)]">$INFO[Container(6913).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(18) + [Skin.String(Custom10PanelType,3) | Skin.String(Custom10PanelType,5) | Skin.String(Custom10PanelType,6) | Skin.String(Custom10PanelType,7) | Skin.String(Custom10PanelType,8) | Skin.String(Custom10PanelType,9) | Skin.String(Custom10PanelType,13) | Skin.String(Custom10PanelType,15)]">$INFO[Container(6913).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(19) + [Skin.String(Custom11PanelType,2) | Skin.String(Custom11PanelType,4) | Skin.String(Custom11PanelType,10) | Skin.String(Custom11PanelType,11) | Skin.String(Custom11PanelType,12)]">$INFO[Container(6915).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(19) + [Skin.String(Custom11PanelType,3) | Skin.String(Custom11PanelType,5) | Skin.String(Custom11PanelType,6) | Skin.String(Custom11PanelType,7) | Skin.String(Custom11PanelType,8) | Skin.String(Custom11PanelType,9) | Skin.String(Custom11PanelType,13) | Skin.String(Custom11PanelType,15)]">$INFO[Container(6915).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(20) + [Skin.String(Custom12PanelType,2) | Skin.String(Custom12PanelType,4) | Skin.String(Custom12PanelType,10) | Skin.String(Custom12PanelType,11) | Skin.String(Custom12PanelType,12)]">$INFO[Container(6917).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(20) + [Skin.String(Custom12PanelType,3) | Skin.String(Custom12PanelType,5) | Skin.String(Custom12PanelType,6) | Skin.String(Custom12PanelType,7) | Skin.String(Custom12PanelType,8) | Skin.String(Custom12PanelType,9) | Skin.String(Custom12PanelType,13) | Skin.String(Custom12PanelType,15)]">$INFO[Container(6917).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(21) + [Skin.String(Custom13PanelType,2) | Skin.String(Custom13PanelType,4) | Skin.String(Custom13PanelType,10) | Skin.String(Custom13PanelType,11) | Skin.String(Custom13PanelType,12)]">$INFO[Container(6919).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(21) + [Skin.String(Custom13PanelType,3) | Skin.String(Custom13PanelType,5) | Skin.String(Custom13PanelType,6) | Skin.String(Custom13PanelType,7) | Skin.String(Custom13PanelType,8) | Skin.String(Custom13PanelType,9) | Skin.String(Custom13PanelType,13) | Skin.String(Custom13PanelType,15)]">$INFO[Container(6919).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(22) + [Skin.String(Custom14PanelType,2) | Skin.String(Custom14PanelType,4) | Skin.String(Custom14PanelType,10) | Skin.String(Custom14PanelType,11) | Skin.String(Custom14PanelType,12)]">$INFO[Container(6921).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(22) + [Skin.String(Custom14PanelType,3) | Skin.String(Custom14PanelType,5) | Skin.String(Custom14PanelType,6) | Skin.String(Custom14PanelType,7) | Skin.String(Custom14PanelType,8) | Skin.String(Custom14PanelType,9) | Skin.String(Custom14PanelType,13) | Skin.String(Custom14PanelType,15)]">$INFO[Container(6921).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(23) + [Skin.String(Custom15PanelType,2) | Skin.String(Custom15PanelType,4) | Skin.String(Custom15PanelType,10) | Skin.String(Custom15PanelType,11) | Skin.String(Custom15PanelType,12)]">$INFO[Container(6923).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(23) + [Skin.String(Custom15PanelType,3) | Skin.String(Custom15PanelType,5) | Skin.String(Custom15PanelType,6) | Skin.String(Custom15PanelType,7) | Skin.String(Custom15PanelType,8) | Skin.String(Custom15PanelType,9) | Skin.String(Custom15PanelType,13) | Skin.String(Custom15PanelType,15)]">$INFO[Container(6923).ListItem.Art(thumb)]</value>
-		<value condition="Container(850).HasFocus(24) + [Skin.String(Custom16PanelType,2) | Skin.String(Custom16PanelType,4) | Skin.String(Custom16PanelType,10) | Skin.String(Custom16PanelType,11) | Skin.String(Custom16PanelType,12)]">$INFO[Container(6925).ListItem.Art(poster)]</value>
-		<value condition="Container(850).HasFocus(24) + [Skin.String(Custom16PanelType,3) | Skin.String(Custom16PanelType,5) | Skin.String(Custom16PanelType,6) | Skin.String(Custom16PanelType,7) | Skin.String(Custom16PanelType,8) | Skin.String(Custom16PanelType,9) | Skin.String(Custom16PanelType,13) | Skin.String(Custom16PanelType,15)]">$INFO[Container(6925).ListItem.Art(thumb)]</value>
-	</variable>
-	
 	<variable name="CustomPanelStraitLayoutLabel">
 		<value condition="[Container(850).HasFocus(7) + Skin.String(Custom1PanelType,10)] | [Container(850).HasFocus(8) + Skin.String(Custom2PanelType,10)] | [Container(850).HasFocus(9) + Skin.String(Custom3PanelType,10)] | [Container(850).HasFocus(10) + Skin.String(Custom4PanelType,10)] | [Container(850).HasFocus(11) + Skin.String(Custom5PanelType,10)] | [Container(850).HasFocus(12) + Skin.String(Custom6PanelType,10)] | [Container(850).HasFocus(13) + Skin.String(Custom7PanelType,10)] | [Container(850).HasFocus(14) + Skin.String(Custom8PanelType,10)]
 		| [Container(850).HasFocus(17) + Skin.String(Custom9PanelType,10)] | [Container(850).HasFocus(18) + Skin.String(Custom10PanelType,10)] | [Container(850).HasFocus(19) + Skin.String(Custom11PanelType,10)] | [Container(850).HasFocus(20) + Skin.String(Custom12PanelType,10)] | [Container(850).HasFocus(21) + Skin.String(Custom13PanelType,10)] | [Container(850).HasFocus(22) + Skin.String(Custom14PanelType,10)] | [Container(850).HasFocus(23) + Skin.String(Custom15PanelType,10)] | [Container(850).HasFocus(24) + Skin.String(Custom16PanelType,10)]">$INFO[ListItem.Label]$INFO[ListItem.Premiered, (,)]</value>
@@ -193,7 +123,51 @@
 					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + Skin.String($PARAM[CustomPanelNumber]TopAspect,wide)] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + Skin.String($PARAM[CustomPanelNumber]FavouriteTopAspect,wide)]">CustomPanelWideCover</include>
 					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + Skin.String($PARAM[CustomPanelNumber]TopAspect,square)] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + Skin.String($PARAM[CustomPanelNumber]FavouriteTopAspect,square)]">CustomPanelSquareCover</include>
 					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,14)">CustomPanelSquareCover</include>
-					<imagepath diffuse="covers/home-panel-movie-cover-diffuse.png" background="true">$VAR[CustomPanelThumbTop]</imagepath>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,2)" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,3)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,4)" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,5)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,6)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,7)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,8)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,9)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,10)" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,11)" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,12)" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + [String.IsEmpty(Skin.String($PARAM[CustomPanelNumber]TopAspect)) | Skin.String($PARAM[CustomPanelNumber]TopAspect,poster)]] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + [String.IsEmpty(Skin.String($PARAM[CustomPanelNumber]FavouriteTopAspect)) | Skin.String($PARAM[CustomPanelNumber]FavouriteTopAspect,poster)]]" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + Skin.String($PARAM[CustomPanelNumber]TopAspect,wide)] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + Skin.String($PARAM[CustomPanelNumber]FavouriteTopAspect,wide)]" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + Skin.String($PARAM[CustomPanelNumber]TopAspect,square)] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + Skin.String($PARAM[CustomPanelNumber]FavouriteTopAspect,square)]" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,14)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDTop]" />
+					</include>
 				</control>
 				<include condition="Skin.String($PARAM[CustomPanelNumber]Type,2)">CustomPanelRecentMoviesTitle</include>
 				<include condition="Skin.String($PARAM[CustomPanelNumber]Type,3)">CustomPanelRecentEpisodesTitle</include>
@@ -298,7 +272,51 @@
 					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + [String.IsEmpty(Skin.String($PARAM[CustomPanelNumber]BottomAspect)) | Skin.String($PARAM[CustomPanelNumber]BottomAspect,poster)]] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + [String.IsEmpty(Skin.String($PARAM[CustomPanelNumber]FavouriteBottomAspect)) | Skin.String($PARAM[CustomPanelNumber]FavouriteBottomAspect,poster)]]">CustomPanelStraitCover</include>
 					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + Skin.String($PARAM[CustomPanelNumber]BottomAspect,wide)] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + Skin.String($PARAM[CustomPanelNumber]FavouriteBottomAspect,wide)]">CustomPanelWideCover</include>
 					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + Skin.String($PARAM[CustomPanelNumber]BottomAspect,square)] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + Skin.String($PARAM[CustomPanelNumber]FavouriteBottomAspect,square)]">CustomPanelSquareCover</include>
-					<imagepath diffuse="covers/home-panel-movie-cover-diffuse.png" background="true">$VAR[CustomPanelThumbBottom]</imagepath>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,2)" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,3)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,4)" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,5)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,6)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,7)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,8)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,9)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,10)" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,11)" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,12)" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + [String.IsEmpty(Skin.String($PARAM[CustomPanelNumber]TopAspect)) | Skin.String($PARAM[CustomPanelNumber]TopAspect,poster)]] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + [String.IsEmpty(Skin.String($PARAM[CustomPanelNumber]FavouriteTopAspect)) | Skin.String($PARAM[CustomPanelNumber]FavouriteTopAspect,poster)]]" content="CustomPanelPoster">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + Skin.String($PARAM[CustomPanelNumber]TopAspect,wide)] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + Skin.String($PARAM[CustomPanelNumber]FavouriteTopAspect,wide)]" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="[Skin.String($PARAM[CustomPanelNumber]Type,13) + Skin.String($PARAM[CustomPanelNumber]TopAspect,square)] | [Skin.String($PARAM[CustomPanelNumber]Type,15) + Skin.String($PARAM[CustomPanelNumber]FavouriteTopAspect,square)]" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
+					<include condition="Skin.String($PARAM[CustomPanelNumber]Type,14)" content="CustomPanelThumb">
+						<param name="ContainerID" value="$PARAM[ContainerIDBottom]" />
+					</include>
 				</control>
 				<include condition="Skin.String($PARAM[CustomPanelNumber]Type,8)">CustomPanelMusicAddonsTitle</include>
 				<include condition="![Skin.String($PARAM[CustomPanelNumber]Type,8) | Skin.String($PARAM[CustomPanelNumber]Type,10) | Skin.String($PARAM[CustomPanelNumber]Type,11) | Skin.String($PARAM[CustomPanelNumber]Type,12) | Skin.String($PARAM[CustomPanelNumber]Type,13) | Skin.String($PARAM[CustomPanelNumber]Type,15)]">CustomPanelRandomTitle</include>
@@ -1994,6 +2012,14 @@
 		<height>110</height>
 		<aspectratio align="right">keep</aspectratio>
 		<fadetime>IconCrossfadeTime</fadetime>
+	</include>
+
+	<include name="CustomPanelPoster">
+		<imagepath diffuse="covers/home-panel-movie-cover-diffuse.png" background="true">$INFO[Container($PARAM[ContainerID]).ListItem.Art(poster)]</imagepath>
+	</include>
+	
+	<include name="CustomPanelThumb">
+		<imagepath diffuse="covers/home-panel-movie-cover-diffuse.png" background="true">$INFO[Container($PARAM[ContainerID]).ListItem.Art(thumb)]</imagepath>
 	</include>
 	
 	<include name="CustomPanelItemlayoutLabel">


### PR DESCRIPTION
Creatng custom top/bottom widgets with movies and tv shows returned widgets with empty artwork.
Because custom panel types 13 and 15 used only ListItem.Art(thumb)
This PR allows the usage of ListItem.Art(poster) in custom top/bottom widgets if poster is selected as the target aspect ratio.